### PR TITLE
feat: Update trust for Cinema4D

### DIFF
--- a/autopkg_src/overrides/Cinema4D.munki.recipe
+++ b/autopkg_src/overrides/Cinema4D.munki.recipe
@@ -73,45 +73,35 @@ pkgutil --forget com.maxon.Cinema4D-R%MAJOR_VERSION%.pkg</string>
 	<key>ParentRecipeTrustInfo</key>
 	<dict>
 		<key>non_core_processors</key>
-		<dict>
-			<key>com.github.homebysix.FindAndReplace/FindAndReplace</key>
-			<dict>
-				<key>git_hash</key>
-				<string>dc086969ec741e70edcf24774d50fba627732496</string>
-				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.homebysix-recipes/FindAndReplace/FindAndReplace.py</string>
-				<key>sha256_hash</key>
-				<string>bb19af8502c6531346e06767b128cee20532647d31b529af2deff1136e550bd8</string>
-			</dict>
-		</dict>
+		<dict/>
 		<key>parent_recipes</key>
 		<dict>
 			<key>com.github.foigus.download.Cinema4D</key>
 			<dict>
 				<key>git_hash</key>
-				<string>5779080fdb3d6b7273dbdc89d080563a24fba808</string>
+				<string>eb60cf3cb114b704c8ed6f4204479f2a08e10de8</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.download.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>a0839cdc38bebbda9a083733883dd98f511c3b98892e7c8743fd2e1c6e003dd5</string>
+				<string>0cd61ff26adf2fb75d7782fde99e0c9f00d1d8bdfd6e19a8638579d7cf5f053f</string>
 			</dict>
 			<key>com.github.foigus.munki.Cinema4D</key>
 			<dict>
 				<key>git_hash</key>
-				<string>7286a479e610254b0048f8b726915e4baaa6c68a</string>
+				<string>fd77c1788c559704b47e57876f7024177bef9087</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.munki.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.munki.recipe</string>
 				<key>sha256_hash</key>
-				<string>f9226bb9ff1dd3030f3e0806f3716402cd7f9bed4d327655156a6b77a79c0026</string>
+				<string>7a8c28f482dc8e3a3e82ebd1e137b987d269079bf5ba3eb2770bcb4888625867</string>
 			</dict>
 			<key>com.github.foigus.pkg.Cinema4D</key>
 			<dict>
 				<key>git_hash</key>
-				<string>5779080fdb3d6b7273dbdc89d080563a24fba808</string>
+				<string>140c6549f4c53458aa7393cd14fef9fd940816dc</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.pkg.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.pkg.recipe</string>
 				<key>sha256_hash</key>
-				<string>487e9a5d1b4061ca56ccc283f2fd499fab1f8539368a2ca2d750dd3e0f883e4a</string>
+				<string>bafa02d001f19b3058fb372202914b127d14eedf25f8f93b001110a34ea9de8a</string>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
autopkg_src/overrides/Cinema4D.munki.recipe: FAILED
    Processor com.github.homebysix.FindAndReplace/FindAndReplace contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.homebysix-recipes/FindAndReplace/FindAndReplace.py
    
    Parent recipe com.github.foigus.download.Cinema4D contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.download.recipe
    commit eb60cf3cb114b704c8ed6f4204479f2a08e10de8
    Author: foigus <ferguspa@yahoo.com>
    Date:   Mon Dec 11 18:49:04 2023 -0600
    
        Deprecating Maxon Cinema 4D Perpetual
        
        Maxon is no longer developing perpetual releases of Cinema 4D--please see issue #133 for further information https://github.com/autopkg/foigus-recipes/issues/133 .
    
    commit 140c6549f4c53458aa7393cd14fef9fd940816dc
    Author: foigus <ferguspa@yahoo.com>
    Date:   Mon Dec 11 18:46:32 2023 -0600
    
        Reversing a few incorrect changes
        
        Cinema 4D R25 is the last perpetual version of Cinema 4D.  Fixing the recipes to reflect reality.
    
    commit fd77c1788c559704b47e57876f7024177bef9087
    Author: foigus <ferguspa@yahoo.com>
    Date:   Wed Dec 6 10:04:22 2023 -0600
    
        Updating for S26 and Maxon website changes
    diff --git a/Maxon/Cinema4DPerpetual.download.recipe b/Maxon/Cinema4DPerpetual.download.recipe
    index e282476..743f75d 100644
    --- a/Maxon/Cinema4DPerpetual.download.recipe
    +++ b/Maxon/Cinema4DPerpetual.download.recipe
    @@ -6,16 +6,13 @@
     	<string>Downloads the latest version of Cinema 4D.
     
     NOTES:
    -- Set MAJOR_VERSION to the desired major version of Cinema 4D
    -- This recipe depends on homebysix's FindAndReplace.  Add homebysix's repo via:
    -
    -autopkg repo-add homebysix-recipes</string>
    +- Set MAJOR_VERSION to the desired major version of Cinema 4D</string>
     	<key>Identifier</key>
     	<string>com.github.foigus.download.Cinema4D</string>
     	<key>Input</key>
     	<dict>
     		<key>MAJOR_VERSION</key>
    -		<string>25</string>
    +		<string>26</string>
     		<key>NAME</key>
     		<string>Cinema4DPerpetual_R%MAJOR_VERSION%</string>
     	</dict>
    @@ -24,49 +21,30 @@ autopkg repo-add homebysix-recipes</string>
     	<key>Process</key>
     	<array>
     		<dict>
    +			<key>Processor</key>
    +			<string>DeprecationWarning</string>
     			<key>Arguments</key>
     			<dict>
    -				<key>re_pattern</key>
    -				<string>_nuxt\/static\/[\d]+\/en\/downloads\/cinema-4d-r%MAJOR_VERSION%-downloads\/payload\.js</string>
    -				<key>result_output_var_name</key>
    -				<string>url_suffix</string>
    -				<key>url</key>
    -				<string>https://www.maxon.net/en/downloads/cinema-4d-r%MAJOR_VERSION%-downloads/</string>
    +				<key>warning_message</key>
    +				<string>This recipe is deprecated and will soon be removed.  Maxon is no longer developing perpetual releases of Cinema 4D--please see issue #133 for further information https://github.com/autopkg/foigus-recipes/issues/133 .</string>
     			</dict>
    -			<key>Processor</key>
    -			<string>URLTextSearcher</string>
     		</dict>
     		<dict>
     			<key>Arguments</key>
     			<dict>
     				<key>re_pattern</key>
    -				<string>https:\\u002F\\u002Fstmaxonappprod\.blob\.core\.windows\.net\\u002Fmx-package-production\\u002Fwebsite\\u002Fupdates\\u002F%MAJOR_VERSION%[\d\.]+_CL[\d]+\\u002FCinema4D_R%MAJOR_VERSION%_%MAJOR_VERSION%[\d\.]+_Mac\.dmg</string>
    -				<key>result_output_var_name</key>
    -				<string>encoded_download_url</string>
    +				<string>https:\/\/stmaxonappprod.blob.core.windows.net\/mx-package-production\/website\/updates\/%MAJOR_VERSION%[\d\.]+_CL[\d]+\/Cinema4D_R%MAJOR_VERSION%_%MAJOR_VERSION%[\d\.]+_Mac\.dmg</string>
     				<key>url</key>
    -				<string>https://www.maxon.net/%url_suffix%</string>
    +				<string>https://www.maxon.net/en/downloads/cinema-4d-r%MAJOR_VERSION%-downloads</string>
     			</dict>
     			<key>Processor</key>
     			<string>URLTextSearcher</string>
     		</dict>
    -		<dict>
    -			<key>Arguments</key>
    -			<dict>
    -				<key>find</key>
    -				<string>\u002F</string>
    -				<key>input_string</key>
    -				<string>%encoded_download_url%</string>
    -				<key>replace</key>
    -				<string>/</string>
    -			</dict>
    -			<key>Processor</key>
    -			<string>com.github.homebysix.FindAndReplace/FindAndReplace</string>
    -		</dict>
     		<dict>
     			<key>Arguments</key>
     			<dict>
     				<key>url</key>
    -				<string>%output_string%</string>
    +				<string>%match%</string>
     			</dict>
     			<key>Processor</key>
     			<string>URLDownloader</string>
    
    Parent recipe com.github.foigus.munki.Cinema4D contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.munki.recipe
    commit fd77c1788c559704b47e57876f7024177bef9087
    Author: foigus <ferguspa@yahoo.com>
    Date:   Wed Dec 6 10:04:22 2023 -0600
    
        Updating for S26 and Maxon website changes
    diff --git a/Maxon/Cinema4DPerpetual.munki.recipe b/Maxon/Cinema4DPerpetual.munki.recipe
    index 1b9c9c7..23bd031 100644
    --- a/Maxon/Cinema4DPerpetual.munki.recipe
    +++ b/Maxon/Cinema4DPerpetual.munki.recipe
    @@ -15,7 +15,7 @@ autopkg repo-add homebysix-recipes</string>
     	<key>Input</key>
     	<dict>
     		<key>MAJOR_VERSION</key>
    -		<string>25</string>
    +		<string>26</string>
     		<key>MUNKI_REPO_SUBDIR</key>
     		<string>apps/maxon</string>
     		<key>NAME</key>
    
    Parent recipe com.github.foigus.pkg.Cinema4D contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.foigus-recipes/Maxon/Cinema4DPerpetual.pkg.recipe
    commit 140c6549f4c53458aa7393cd14fef9fd940816dc
    Author: foigus <ferguspa@yahoo.com>
    Date:   Mon Dec 11 18:46:32 2023 -0600
    
        Reversing a few incorrect changes
        
        Cinema 4D R25 is the last perpetual version of Cinema 4D.  Fixing the recipes to reflect reality.
    
    commit fd77c1788c559704b47e57876f7024177bef9087
    Author: foigus <ferguspa@yahoo.com>
    Date:   Wed Dec 6 10:04:22 2023 -0600
    
        Updating for S26 and Maxon website changes
    diff --git a/Maxon/Cinema4DPerpetual.pkg.recipe b/Maxon/Cinema4DPerpetual.pkg.recipe
    index f14cca5..7b0752e 100644
    --- a/Maxon/Cinema4DPerpetual.pkg.recipe
    +++ b/Maxon/Cinema4DPerpetual.pkg.recipe
    @@ -24,7 +24,7 @@ install_dir=`dirname $0`
     # for R23 installation from https://www.maxon.net/en-us/support/downloads/
     "${install_dir}/Maxon Cinema 4D Full Installer.app/Contents/MacOS/installbuilder.sh" --mode unattended --unattendedmodeui none</string>
     		<key>MAJOR_VERSION</key>
    -		<string>25</string>
    +		<string>26</string>
     		<key>NAME</key>
     		<string>Cinema4DPerpetual_R%MAJOR_VERSION%</string>
     	</dict>
    @@ -49,11 +49,11 @@ install_dir=`dirname $0`
     			<key>Arguments</key>
     			<dict>
     				<key>re_pattern</key>
    -				<string>https:\\u002F\\u002Fstmaxonappprod\.blob\.core\.windows\.net\\u002Fmx-package-production\\u002Fwebsite\\u002Fupdates\\u002F(%MAJOR_VERSION%[\d\.]+)_CL[\d]+\\u002FCinema4D_R%MAJOR_VERSION%_%MAJOR_VERSION%[\d\.]+_Mac\.dmg</string>
    +				<string>https:\/\/stmaxonappprod.blob.core.windows.net\/mx-package-production\/website\/updates\/(%MAJOR_VERSION%[\d\.]+)_CL[\d]+\/Cinema4D_R%MAJOR_VERSION%_%MAJOR_VERSION%[\d\.]+_Mac\.dmg</string>
     				<key>result_output_var_name</key>
     				<string>version</string>
     				<key>url</key>
    -				<string>https://www.maxon.net/%url_suffix%</string>
    +				<string>https://www.maxon.net/en/downloads/cinema-4d-r%MAJOR_VERSION%-downloads</string>
     			</dict>
     			<key>Processor</key>
     			<string>URLTextSearcher</string>
    
