### PR TITLE
feat: Update trust for Brave

### DIFF
--- a/autopkg_src/overrides/Brave.munki.recipe
+++ b/autopkg_src/overrides/Brave.munki.recipe
@@ -43,18 +43,18 @@
 			<key>com.github.swy.download.BraveUniversal</key>
 			<dict>
 				<key>git_hash</key>
-				<string>39f03c7d098d0178b003a23efc26896e65f155c9</string>
+				<string>c21259be3c9ca28a41775f2c88af1187d91d742e</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.swy-recipes/BraveUniversal/BraveUniversal.download.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.swy-recipes/BraveUniversal/BraveUniversal.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>828189dbb68f1dc1b6f1421738a20dff520a1da9333bce83f065664dc36fedba</string>
+				<string>25679b27b90e9ff09dde00da35cc592fc72131da422107a629bfdde15b037f5b</string>
 			</dict>
 			<key>com.github.swy.munki.BraveUniversal</key>
 			<dict>
 				<key>git_hash</key>
 				<string>39f03c7d098d0178b003a23efc26896e65f155c9</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.swy-recipes/BraveUniversal/BraveUniversal.munki.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.swy-recipes/BraveUniversal/BraveUniversal.munki.recipe</string>
 				<key>sha256_hash</key>
 				<string>28bf690789fdb0627d2f05aa0897eb321168a1cc3fa9dc082daa07ddbb2455c3</string>
 			</dict>


### PR DESCRIPTION
autopkg_src/overrides/Brave.munki.recipe: FAILED
    Parent recipe com.github.swy.download.BraveUniversal contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.swy-recipes/BraveUniversal/BraveUniversal.download.recipe
    commit c21259be3c9ca28a41775f2c88af1187d91d742e
    Author: Armando <armando.siliezar@mtsproservices.com>
    Date:   Wed Dec 6 16:22:14 2023 -0500
    
        Changed the plist_version_key to CFBundleShortVersionString to get the correct package version
    diff --git a/BraveUniversal/BraveUniversal.download.recipe b/BraveUniversal/BraveUniversal.download.recipe
    index 3e1de45..5b4ae4b 100644
    --- a/BraveUniversal/BraveUniversal.download.recipe
    +++ b/BraveUniversal/BraveUniversal.download.recipe
    @@ -51,7 +51,7 @@
     				<key>input_plist_path</key>
     				<string>%pathname%/Brave Browser.app/Contents/Info.plist</string>
     				<key>plist_version_key</key>
    -				<string>CFBundleVersion</string>
    +				<string>CFBundleShortVersionString</string>
     			</dict>
     			<key>Processor</key>
     			<string>Versioner</string>
    
