### PR TITLE
feat: Update trust for Postman

### DIFF
--- a/autopkg_src/overrides/Postman.munki.recipe
+++ b/autopkg_src/overrides/Postman.munki.recipe
@@ -62,18 +62,18 @@
 			<key>com.github.dataJAR-recipes.download.postman</key>
 			<dict>
 				<key>git_hash</key>
-				<string>86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28</string>
+				<string>97d1790acdd47aa96895df8b984cb7f637d8ec9c</string>
 				<key>path</key>
-				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe</string>
 				<key>sha256_hash</key>
-				<string>31aa97301c9211009904fb12659e16162e33cdc63c5fb1ff58ea2a2fdf87e9a3</string>
+				<string>9599dee811e65e7e7563149d8505ddee2ec5575f3d65186bf7d9197508f08499</string>
 			</dict>
 			<key>com.github.dataJAR-recipes.munki.postman</key>
 			<dict>
 				<key>git_hash</key>
 				<string>86f0ee3f3344a8895a39f2d6ab7c8ea0dad58e28</string>
 				<key>path</key>
-				<string>~/work/automunki/automunki/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.munki.recipe</string>
+				<string>~/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.munki.recipe</string>
 				<key>sha256_hash</key>
 				<string>bda6e69a35a716d573565d0bde7b34536d40fcc89e0f80030218279f7d110bdf</string>
 			</dict>


### PR DESCRIPTION
autopkg_src/overrides/Postman.munki.recipe: FAILED
    Parent recipe com.github.dataJAR-recipes.download.postman contents differ from expected.
        Path: /Users/runner/work/automunki-fleet/automunki-fleet/autopkg_src/repos/com.github.autopkg.dataJAR-recipes/Postman/Postman.download.recipe
    commit 97d1790acdd47aa96895df8b984cb7f637d8ec9c
    Author: Paul Cossey <paul_cossey@hotmail.com>
    Date:   Sat Jul 22 12:45:04 2023 +0100
    
        Update Postman.download.recipe
        
        - Adds SUPPORTED_ARCH variable.
        
        - Resolves https://github.com/autopkg/dataJAR-recipes/issues/297
    diff --git a/Postman/Postman.download.recipe b/Postman/Postman.download.recipe
    index 7691427..46febf4 100644
    --- a/Postman/Postman.download.recipe
    +++ b/Postman/Postman.download.recipe
    @@ -5,9 +5,9 @@
         <key>Description</key>
         <string>Downloads the current release version of Postman. Taken from bnpl-recipes repo. thanks to TSPARR for the Code Signature Check.
     
    -For Intel set DOWNLOAD_ARCH to "64" (default)
    +For Intel set DOWNLOAD_ARCH to "64" and set SUPPORTED_ARCH to "x86_64" (default)
     
    -For Apple Silicon set DOWNLOAD_ARCH to "arm64"</string>
    +For Apple Silicon set both DOWNLOAD_ARCH and SUPPORTED_ARCH to "arm64"</string>
         <key>Identifier</key>
         <string>com.github.dataJAR-recipes.download.postman</string>
         <key>Input</key>
    @@ -16,6 +16,8 @@ For Apple Silicon set DOWNLOAD_ARCH to "arm64"</string>
             <string>Postman</string>
             <key>DOWNLOAD_ARCH</key>
             <string>64</string>
    +        <key>SUPPORTED_ARCH</key>
    +        <string>x86_64</string>
         </dict>
         <key>MinimumVersion</key>
         <string>2.7.2</string>
    
